### PR TITLE
Do not make target dirs if not necessary

### DIFF
--- a/src/uberdeps/api.clj
+++ b/src/uberdeps/api.clj
@@ -142,7 +142,8 @@
        (println (str "[uberdeps] Packaging " target "...")))
      (binding [*seen-files (atom {})
                *seen-libs  (atom #{})]
-       (.mkdirs (.getParentFile (io/file target)))
+       (when-let [p (.getParentFile (io/file target))]
+         (.mkdirs p))
        (with-open [out (JarOutputStream. (BufferedOutputStream. (FileOutputStream. target)))]
          (package-libs deps-map out)
          (package-paths deps-map out)))


### PR DESCRIPTION
Fixes the following:

```bash
> clj -A:uberjar --target standalone.jar
[uberdeps] Packaging standalone.jar...
Exception in thread "main" java.lang.NullPointerException
	at uberdeps.api$package$fn__923.invoke(api.clj:145)
	at uberdeps.api$package.invokeStatic(api.clj:143)
	at uberdeps.api$package.invoke(api.clj:136)
	at uberdeps.uberjar$_main$fn__932.invoke(uberjar.clj:23)
	at uberdeps.uberjar$_main.invokeStatic(uberjar.clj:22)
	at uberdeps.uberjar$_main.doInvoke(uberjar.clj:9)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.main$main_opt.invokeStatic(main.clj:491)
	at clojure.main$main_opt.invoke(main.clj:487)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
```