### PR TITLE
Use platform independent jar path separator

### DIFF
--- a/src/uberdeps/api.clj
+++ b/src/uberdeps/api.clj
@@ -40,7 +40,7 @@
       (when (#{:debug :info :warn} level)
         (println (str "! Duplicate entry \"" path "\" from \"" context "\" already seen in \"" context' "\"")))
       (let [entry (doto
-                    (JarEntry. path)
+                    (JarEntry. (str/replace path (File/separator) "/"))
                     (.setLastModifiedTime last-modified))]
         (.putNextEntry out entry)
         (io/copy in out)


### PR DESCRIPTION
For #16, Windows path separator \ is not valid as a jar path separator so we convert all path separator to /