### PR TITLE
Support --main-class option to create manifest for

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Supported command-line options are:
 --deps-file <file>                Which deps.edn file to use to build classpath. Defaults to 'deps.edn'
 --aliases <alias:alias:...>       Colon-separated list of alias names to include from deps file. Defaults to nothing
 --target <file>                   Jar file to ouput to. Defaults to 'target/<directory-name>.jar'
+--main-class <ns>                 Main class, if it exists (e.g. app.core)
 --level (debug|info|warn|error)   Verbose level. Defaults to debug
 ```
 
@@ -52,6 +53,43 @@ If your project has a `-main` function, you can run it from within the generated
 ```
 java -cp target/<your project>.jar clojure.main -m <your namespace with main>
 ```
+
+## Creating an executable jar
+
+Given your project has a `-main` function like below:
+
+```clojure
+(ns app.core
+  (:gen-class))
+
+(defn -main [& args]
+      (println "Hello world"))
+```
+
+You can create an executable jar with these steps:
+
+```bash
+# ensure dir exists
+mkdir classes
+
+# aot compile
+clj -e "(compile 'app.core)"
+
+# uberjar with --main-class option
+clojure -A:uberjar --main-class app.core
+```
+
+This will create a manifest in the jar under META-INF/MANIFEST.MF,
+which then allows you to run your jar directly:
+
+```
+java -jar target/<your-project>.jar
+```
+
+For more information on AOT compiling in tools.deps, have a look at the official
+[guide](https://clojure.org/guides/deps_and_cli#aot_compilation).
+
+
 
 ## Changelog
 

--- a/src/uberdeps/uberjar.clj
+++ b/src/uberdeps/uberjar.clj
@@ -1,27 +1,28 @@
 (ns uberdeps.uberjar
   (:require
-   [clojure.edn :as edn]
-   [uberdeps.api :as api]
-   [clojure.string :as str]
-   [clojure.java.io :as io]))
+    [clojure.edn :as edn]
+    [uberdeps.api :as api]
+    [clojure.string :as str]
+    [clojure.java.io :as io]))
 
 
 (defn -main [& {:as args}]
   (let [deps-file (or (get args "--deps-file") "deps.edn")
         target    (or (get args "--target")
-                    (as-> (io/file ".") %
-                      (.getCanonicalFile %)
-                      (.getName %)
-                      (str "target/" % ".jar")))
+                      (as-> (io/file ".") %
+                            (.getCanonicalFile %)
+                            (.getName %)
+                            (str "target/" % ".jar")))
         aliases   (-> (or (get args "--aliases") "")
-                    (str/split  #":")
-                    (->> (remove str/blank?)
-                      (map keyword)
-                      (into #{})))
+                      (str/split  #":")
+                      (->> (remove str/blank?)
+                           (map keyword)
+                           (into #{})))
+        main-class (get args "--main-class")
         level     (keyword (or (get args "--level") "debug"))]
     (binding [api/level level]
       (api/package
         (edn/read-string (slurp deps-file))
         target
-        {:aliases aliases}))
+        {:aliases aliases :main-class main-class}))
     (shutdown-agents)))


### PR DESCRIPTION
Fixes #13 

I've verified the manifest looks identical to one created by the `jar` tool.

This creates the manifest only if --main-class is specified, keeping behaviour the same as current if not specified. An alternative would be to create the manifest regardless, just without the main-class attribute if it is not specified. 

What do you think?