### PR TITLE
Ignore Emacs backup files

### DIFF
--- a/src/uberdeps/api.clj
+++ b/src/uberdeps/api.clj
@@ -38,7 +38,7 @@
   [#"project.clj"
    #"LICENSE"
    #"COPYRIGHT"
-   #".*\.pom"
+   #".*(\.pom|~)"
    #"module-info\.class"
    #"(?i)META-INF/.*\.(MF|SF|RSA|DSA)"
    #"(?i)META-INF/(INDEX\.LIST|DEPENDENCIES|NOTICE|LICENSE)(\.txt)?"])


### PR DESCRIPTION
Thanks for the library!

When creating my JARs, I noticed that files edited and backed up by Emacs, which get given a trailing `~` to them, are included in the JAR.

I can see that you can exclude files using: 

https://github.com/tonsky/grumpy/blob/875d0bd15fbf643bc48e34b4a6be3d26e6040140/package/grumpy/package.clj#L25-L32

But it would be great if it can be done by default.

Please consider including this modified regular expression which would also exclude Emacs backup files by default.

Thank you