### PR TITLE
Fix relative paths issue when deps.edn is a symlink

### DIFF
--- a/src/uberdeps/uberjar.clj
+++ b/src/uberdeps/uberjar.clj
@@ -17,7 +17,7 @@
 
 (defn -main [& args]
   (let [deps-file (or (get-option-value args "--deps-file") "deps.edn")
-        deps-dir  (-> (io/file deps-file) (.getCanonicalFile) (.getParentFile))
+        deps-dir  (-> (io/file deps-file) (.getAbsoluteFile) (.getParentFile))
         target    (or (get-option-value args "--target")
                     (as-> (io/file ".") %
                       (.getCanonicalFile %)


### PR DESCRIPTION
Resolve paths relative to the location of deps.edn, not relative to the file it points at.

See repro case at https://github.com/imrekoszo/depslink3_2