### PR TITLE
Add replace-paths to further isolate invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ deps.edn:
   :aliases {
     :uberdeps {
       :replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}}
+      :replace-paths []
       :main-opts ["-m" "uberdeps.uberjar"]
     }
   }
@@ -129,7 +130,7 @@ You can invoke Uberdeps from command line at any time without any prior setup.
 Add to your bash aliases:
 
 ```sh
-clj -Sdeps '{:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}}}}}' -M:uberjar -m uberdeps.uberjar
+clj -Sdeps '{:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}} :replace-paths []}}}' -M:uberjar -m uberdeps.uberjar
 ```
 
 Or add to your `~/.clojure/deps.edn`:
@@ -137,6 +138,7 @@ Or add to your `~/.clojure/deps.edn`:
 ```clojure
 :aliases {
   :uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}}
+            :replace-paths []
             :main-opts ["-m" "uberdeps.uberjar"]}
 }
 ```


### PR DESCRIPTION
A `user.clj` or `data_readers.clj` on the project path might affect the operation of the tool unless the project's paths are overridden. See also: https://ask.clojure.org/index.php/9857/could-option-that-variant-sdeps-avoid-having-specify-alias?show=9884#a9884