### PR TITLE
Use ["src"] as :paths if unset, like clojure

### DIFF
--- a/src/uberdeps/api.clj
+++ b/src/uberdeps/api.clj
@@ -233,7 +233,7 @@
 
 (defn package-paths [deps-map out]
   (let [paths (concat
-                (:paths deps-map)
+                (:paths deps-map ["src"])
                 (:extra-paths (:args-map deps-map)))]
     (doseq [path (sort paths)]
       (binding [context (str path "/**")]


### PR DESCRIPTION
Uberdeps should consider `:paths` to be set to `["src"]` when it's empty, like `clojure` CLI does.

Here is a script for demonstration:

```
#!/bin/sh -x
rm -rf no-paths/
mkdir no-paths
cd no-paths
mkdir src
echo '{}' > deps.edn
echo '(ns foo)' > src/foo.clj
clojure -Spath |grep -o ^src:
clj -Sdeps '{:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}} :replace-paths []}}}' -M:uberjar -m uberdeps.uberjar
unzip -l target/no-paths.jar

echo '{:paths ["src"]}' > deps.edn
clj -Sdeps '{:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}} :replace-paths []}}}' -M:uberjar -m uberdeps.uberjar
unzip -l target/no-paths.jar
```

Output:

```
$ ./no-paths.sh
+ rm -rf no-paths/
+ mkdir no-paths
+ cd no-paths
+ mkdir src
+ echo {}
+ echo (ns foo)
+ clojure -Spath
+ grep -o ^src:
src:
+ clj -Sdeps {:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}} :replace-paths []}}} -M:uberjar -m uberdeps.uberjar
[uberdeps] Packaging target/no-paths.jar...
[uberdeps] Packaged target/no-paths.jar in 6 ms
+ unzip -l target/no-paths.jar
Archive:  target/no-paths.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2021-01-05 09:13   META-INF/
       65  2021-01-05 09:13   META-INF/MANIFEST.MF
---------                     -------
       65                     2 files
+ echo {:paths ["src"]}
+ clj -Sdeps {:aliases {:uberjar {:replace-deps {uberdeps/uberdeps {:mvn/version "1.0.3"}} :replace-paths []}}} -M:uberjar -m uberdeps.uberjar
[uberdeps] Packaging target/no-paths.jar...
+ src/**
[uberdeps] Packaged target/no-paths.jar in 6 ms
+ unzip -l target/no-paths.jar
Archive:  target/no-paths.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2021-01-05 09:13   META-INF/
       65  2021-01-05 09:13   META-INF/MANIFEST.MF
        9  2021-01-05 09:13   foo.clj
---------                     -------
       74                     3 files
```
