### PR TITLE
Add --exclude cli option to add additional exclusions to uberjar

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Supported command-line options are:
 --deps-file <file>                Which deps.edn file to use to build classpath. Defaults to 'deps.edn'
 --aliases <alias:alias:...>       Colon-separated list of alias names to include from deps file. Defaults to nothing
 --target <file>                   Jar file to ouput to. Defaults to 'target/<directory-name>.jar'
+--exclude <regexp>                Exclude files that match one or more of the Regular Expression given. Can be used multiple times
 --main-class <ns>                 Main class, if it exists (e.g. app.core)
 --multi-release                   Add Multi-Release: true to the manifest. Off by default.
 --level (debug|info|warn|error)   Verbose level. Defaults to debug

--- a/src/uberdeps/api.clj
+++ b/src/uberdeps/api.clj
@@ -26,13 +26,14 @@
 (def ^:private ^:dynamic mergers)
 (def ^:private ^:dynamic context)
 (def ^:private ^:dynamic indent "")
+(def ^:dynamic exclusions)
 
 
 (def ^:dynamic level :debug) ; :debug :info :warn :error
 
 
 ; from https://github.com/seancorfield/depstar/blob/06eb9dea599840b38ec493669c89de5aa1ff2eba/src/hf/depstar/uberjar.clj
-(def ^:dynamic exclusions
+(def default-exclusions
   "Filename patterns to exclude. These are checked with re-matches and
   should therefore be complete filename matches including any path."
   [#"project.clj"
@@ -293,7 +294,8 @@
                *seen-libs  (atom #{})
                *mkdirs     (atom #{})
                *mergeables (atom {})
-               mergers     (merge default-mergers (:mergers opts))]
+               mergers     (merge default-mergers (:mergers opts))
+               exclusions  (into default-exclusions (:exclusions opts))]
        (when-let [p (.getParentFile (io/file target))]
          (.mkdirs p))
        (with-open [out (JarOutputStream. (BufferedOutputStream. (FileOutputStream. target)))]

--- a/src/uberdeps/uberjar.clj
+++ b/src/uberdeps/uberjar.clj
@@ -6,6 +6,13 @@
    [clojure.java.io :as io]
    [clojure.tools.deps.alpha.util.dir :as deps.dir]))
 
+(defn get-options [args]
+  (->> args
+       (partition 2)
+       (group-by first)
+       (map (fn [[option v]]
+              [option (map second v)]))
+       (into {})))
 
 (defn get-option-value [args option]
   (->> args (drop-while #(not= % option)) second))
@@ -13,7 +20,6 @@
 
 (defn get-option [args option]
   (some #(= option %) args))
-
 
 (defn -main [& args]
   (let [deps-file (or (get-option-value args "--deps-file") "deps.edn")
@@ -28,8 +34,11 @@
                     (->> (remove str/blank?)
                       (map keyword)
                       (into #{})))
+        parsed-args (get-options args)
+        exclusions (map re-pattern (parsed-args "--exclude"))
         opts      {:main-class     (get-option-value args "--main-class")
                    :multi-release? (get-option args "--multi-release")
+                   :exclusions     exclusions
                    :aliases        aliases}
         level     (or (some-> (get-option-value args "--level") keyword)
                     :debug)]


### PR DESCRIPTION
@tonsky we're using this fork at @nextjournal and I think a new CLI option could be useful. What do you think?

I've added an helper function to the main file because i'm envisionin the usage of this with multiple `--exclude`. before merging this i'd probably refactor a bit that namespace to use the `get-options` function (and add doc, etc.).